### PR TITLE
relax version dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,17 +28,17 @@
     "test": "grunt"
   },
   "devDependencies": {
-    "grunt": "0.4.2",
+    "grunt": "~0.4.4",
     "grunt-contrib-jshint": "0.6.3",
     "grunt-contrib-nodeunit": "0.3.2",
     "grunt-contrib-clean": "0.5.0",
     "grunt-git-authors": "1.2.0",
-    "grunt-jscs-checker": "0.3.2",
+    "grunt-jscs-checker": "~0.4.1",
     "grunt-release-it": "0.1.1",
     "load-grunt-tasks": "0.3.0"
   },
   "peerDependencies": {
-    "grunt": "0.4.2"
+    "grunt": "~0.4.2"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
- changed peer dependency from a strict grunt 0.4.2 to a compatible
  "^0.4.4".
- updated grunt-jscs-checker to latest because previous version was
  also tied to a strict grunt version via peer dependency.
